### PR TITLE
Moa patch

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,4 +1,5 @@
 /bootstrap/compiled.php
 /vendor
 composer.phar
+composer.lock
 .DS_Store

--- a/api/app/classes/Moa/API/Provider/Magento/Category.php
+++ b/api/app/classes/Moa/API/Provider/Magento/Category.php
@@ -65,7 +65,7 @@ trait Category {
                 // Prepare the model for appending to the collection.
                 $model = array(
                     'id'            => (int) $subCategory->getId(),
-                    'ident'         => $this->_createIdent($subCategory->getName()),
+                    'ident'         => $this->createIdent($subCategory->getName()),
                     'name'          => $subCategory->getName(),
                     'productCount'  => $productCount($subCategory->getId()),
                 );

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "underscore": "~1.5.2",
     "grunt-contrib-cssmin": "~0.7.0",
     "newrelic": "~1.3.1",
-    "node-snapshot": "~0.5.0"
+    "node-snapshot": "0.3.10"
   }
 }


### PR DESCRIPTION
**Call to undefined method `_createIdent()`** occurs when running `phpunit` command in `api/`.

Node.js module Snapshot had to be downgraded to version 0.3.10 in order for the application to work.

